### PR TITLE
[iOS] Fix HEADER_SEARCH_PATHS

### DIFF
--- a/src/ios/BlinkIDReactNative/BlinkIDReactNative.xcodeproj/project.pbxproj
+++ b/src/ios/BlinkIDReactNative/BlinkIDReactNative.xcodeproj/project.pbxproj
@@ -118,7 +118,7 @@
 		A27CCA231E9E57A500BED675 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0830;
+				LastUpgradeCheck = 830;
 				ORGANIZATIONNAME = "Jura Skrlec";
 				TargetAttributes = {
 					A27CCA2A1E9E57A500BED675 = {
@@ -259,12 +259,7 @@
 					"<MicroBlink/MicroBlink.h>",
 					"$(SRCROOT)/../../../iOS/**",
 				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/../../../../react-native/**",
-					"$(SRCROOT)/../../../../react-native/React/**",
-					"$(SRCROOT)/../../../../../ios",
-				);
+				HEADER_SEARCH_PATHS = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -289,12 +284,7 @@
 					"<MicroBlink/MicroBlink.h>",
 					"$(SRCROOT)/../../../iOS/**",
 				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/../../../../react-native/**",
-					"$(SRCROOT)/../../../../react-native/React/**",
-					"$(SRCROOT)/../../../../../ios",
-				);
+				HEADER_SEARCH_PATHS = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = (
 					"-ObjC",

--- a/src/ios/BlinkIDReactNative/BlinkIDReactNative/BlinkIDReactNative.h
+++ b/src/ios/BlinkIDReactNative/BlinkIDReactNative/BlinkIDReactNative.h
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Microblink. All rights reserved.
 //
 
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 
 @interface BlinkIDReactNative : NSObject<RCTBridgeModule>
 

--- a/src/ios/BlinkIDReactNative/BlinkIDReactNative/BlinkIDReactNative.mm
+++ b/src/ios/BlinkIDReactNative/BlinkIDReactNative/BlinkIDReactNative.mm
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import "BlinkIDReactNative.h"
-#import "RCTConvert.h"
+#import <React/RCTConvert.h>
 #import <MicroBlink/MicroBlink.h>
 
 @interface BlinkIDReactNative () <PPScanningDelegate>


### PR DESCRIPTION
A module shouldn't search for `React` headers. This can cause notably errors like `Argument list too long: recursive header expansion failed`.