### PR TITLE
Release/v2.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,19 +21,6 @@ export const BlinkID = Platform.select({
       android: NativeModules.BlinkIDAndroid
 })
 
-const { scan } = BlinkID
-// backwards compat
-BlinkID.scan = async (...args) => {
-  const result = await scan(...args)
-  const { successful={}, cropped={}, face={} } = result.images
-  return {
-    get resultImageSuccessful() { return successful.base64 },
-    get resultImageCropped() { return cropped.base64 },
-    get resultImageFace() { return face.base64 },
-    ...result,
-  }
-}
-
 /**
  * Following exports expose the keys (string constants) for obtaining result values for
  * corresponding result types.
@@ -43,3 +30,4 @@ export const USDLKeys = require('./keys/usdl_keys')
 export const EUDLKeys = require('./keys/eudl_keys')
 export const MYKADKeys = require('./keys/mykad_keys')
 export const PDF417Keys = require('./keys/pdf417_keys')
+export const NZDLFrontKeys = require('./keys/nzdl_front_keys')

--- a/initReactNativeDemoApp.sh
+++ b/initReactNativeDemoApp.sh
@@ -69,7 +69,7 @@ cat > Podfile << EOF
 platform :ios, '8.0'
 
 target 'BlinkIDReactNative' do
-  pod 'PPBlinkID', '~> 2.15.0'
+  pod 'PPBlinkID', '~> 2.17.3'
 end
 EOF
 

--- a/initReactNativeDemoApp.sh
+++ b/initReactNativeDemoApp.sh
@@ -4,7 +4,7 @@
 rm -rf BlinkIDReactNative
 
 # create a sample application
-react-native init --version="0.48.3" BlinkIDReactNative
+react-native init --version="0.55.0" BlinkIDReactNative
 
 # enter into demo project folder
 cd BlinkIDReactNative

--- a/initReactNativeDemoApp.sh
+++ b/initReactNativeDemoApp.sh
@@ -142,7 +142,7 @@ import {
 
 const licenseKey = Platform.select({
       // iOS license key for applicationID: org.reactjs.native.example.BlinkIDReactNative
-      ios: 'E2ONP7QK-SGLUN3RH-YIEFNMOT-Q23AMHC6-U7EIRDKV-ZZJO73HG-3ZOUG574-VLZMR3HC',
+      ios: 'JGB6SUY2-MH7ZOUKB-L7UA7GP5-L3TYCFZQ-I3XGO774-UL225CKU-EOYRYXVH-ZCEPUZN4',
       // android license key for applicationID: com.blinkidreactnative
       android: 'JMXSJB6V-B3JBFNNF-DJWHC444-YZDHLI2P-P6XYVQNJ-TCWNIMXP-5U4F5RZY-L3DU6TK3'
 })

--- a/keys/nzdl_front_keys.js
+++ b/keys/nzdl_front_keys.js
@@ -1,0 +1,46 @@
+/***** Keys for obtaining data on New Zealand driver licenses *****/
+
+/*
+ * First names on New Zealand drivers license.
+ */
+export const FirstNames = "NewZealandDLFirstNames.FirstName";
+
+/*
+ * Surname on New Zealand drivers license
+ */
+export const Surname = "NewZealandDLSurname.Surname";
+
+/*
+ * Date of birth on New Zealand drivers license.
+ */
+export const DateOfBirth = "NewZealandDLDateOfBirth.DateOfBirth";
+
+/*
+ * Expiry date on New Zealand drivers license.
+ */
+export const ExpiryDate = "NewZealandDLExpiryDate.ExpiryDate";
+
+/*
+ * Issue date on New Zealand drivers license.
+ */
+export const IssueDate = "NewZealandDLIssueDate.IssueDate";
+
+/*
+ * License number
+ */
+export const LicenseNumber = "NewZealandDLLicenseNumber.LicenseNumber"
+
+/**
+ * Card version on New Zealand drivers license.
+ */
+export const CardVersion = "NewZealandDLCardVersion.CardVersion"
+
+/**
+ * Donor indicator flag. 
+ */
+export const DonorIndicator = "NewZealandDLDonorIndicator.DonorIndicator"
+
+/*
+ * Address on New Zealand drivers license.
+ */
+export const Address = "NewZealandDLAddress.Address"

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile "com.android.support:appcompat-v7:23.0.1"
     compile "com.facebook.react:react-native:+"
-    compile('com.microblink:blinkid:3.14.0@aar') {
+    compile('com.microblink:blinkid:3.16.0@aar') {
         transitive = false
     }
 }

--- a/src/android/src/main/java/com/microblink/reactnative/blinkid/BlinkIDModule.java
+++ b/src/android/src/main/java/com/microblink/reactnative/blinkid/BlinkIDModule.java
@@ -24,7 +24,6 @@ import com.microblink.activity.ScanCard;
 import com.microblink.hardware.camera.CameraType;
 import com.microblink.image.Image;
 import com.microblink.image.ImageListener;
-import com.microblink.image.ImageType;
 import com.microblink.metadata.MetadataSettings;
 import com.microblink.recognizers.BaseRecognitionResult;
 import com.microblink.recognizers.IResultHolder;
@@ -43,6 +42,8 @@ import com.microblink.recognizers.blinkid.malaysia.mykad.front.MyKadFrontSideRec
 import com.microblink.recognizers.blinkid.malaysia.mykad.front.MyKadFrontSideRecognizerSettings;
 import com.microblink.recognizers.blinkid.mrtd.MRTDRecognitionResult;
 import com.microblink.recognizers.blinkid.mrtd.MRTDRecognizerSettings;
+import com.microblink.recognizers.blinkid.newzealand.driversLicense.front.NewZealandDLFrontRecognitionResult;
+import com.microblink.recognizers.blinkid.newzealand.driversLicense.front.NewZealandDLFrontRecognizerSettings;
 import com.microblink.recognizers.settings.RecognitionSettings;
 import com.microblink.recognizers.settings.RecognizerSettings;
 import com.microblink.results.date.DateResult;
@@ -66,7 +67,7 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
     // js keys for scanning options
     private static final String OPTION_USE_FRONT_CAMERA_JS_KEY = "useFrontCamera";
     private static final String OPTION_ENABLE_BEEP_JS_KEY = "enableBeep";
-    private static final String OPTION_SHOULD_RETURN_CROPPED_IMAGE_JS_KEY = "shouldReturnCroppedImage";
+    private static final String OPTION_SHOULD_RETURN_DOCUMENT_IMAGE_JS_KEY = "shouldReturnDocumentImage";
     private static final String OPTION_SHOULD_RETURN_SUCCESSFUL_IMAGE_JS_KEY = "shouldReturnSuccessfulImage";
     private static final String OPTION_SHOULD_RETURN_FACE_IMAGE_JS_KEY = "shouldReturnFaceImage";
     private static final String RECOGNIZERS_ARRAY_JS_KEY = "recognizers";
@@ -78,13 +79,13 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
     private static final String RECOGNIZER_DOCUMENT_FACE_JS_KEY = "RECOGNIZER_DOCUMENT_FACE";
     private static final String RECOGNIZER_MYKAD_JS_KEY = "RECOGNIZER_MYKAD";
     private static final String RECOGNIZER_PDF417_JS_KEY = "RECOGNIZER_PDF417";
+    private static final String RECOGNIZER_NZDL_FRONT_JS_KEY = "RECOGNIZER_NZDL_FRONT";
 
     // js result keys
     private static final String RESULT_LIST = "resultList";
-    private static final String RESULT_IMAGES = "images";
-    private static final String RESULT_IMAGE_CROPPED = "cropped";
-    private static final String RESULT_IMAGE_SUCCESSFUL = "successful";
-    private static final String RESULT_IMAGE_FACE = "face";
+    private static final String RESULT_IMAGE_DOCUMENT = "resultImageDocument";
+    private static final String RESULT_IMAGE_SUCCESSFUL = "resultImageSuccessful";
+    private static final String RESULT_IMAGE_FACE = "resultImageFace";
     private static final String RESULT_TYPE = "resultType";
     private static final String FIELDS = "fields";
 
@@ -95,6 +96,7 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
     private static final String DOCUMENT_FACE_RESULT_TYPE = "DocumentFace result";
     private static final String MYKAD_RESULT_TYPE = "MyKad result";
     private static final String PDF417_RESULT_TYPE = "PDF417 result";
+    private static final String NZDL_FRONT_RESULT_TYPE = "NZDLFront result";
 
     // java mappings for recognizer types
     private static final int RECOGNIZER_MRTD = 1;
@@ -103,6 +105,7 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
     private static final int RECOGNIZER_DOCUMENT_FACE = 4;
     private static final int RECOGNIZER_MYKAD = 5;
     private static final int RECOGNIZER_PDF417 = 6;
+    private static final int RECOGNIZER_NZDL_FRONT = 7;
 
     private static final int COMPRESSED_IMAGE_QUALITY = 90;
 
@@ -114,9 +117,15 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
     private static final String LOG_TAG = "BlinkID";
 
     private Promise mScanPromise;
-    private boolean mShouldReturnCroppedImage;
+    private boolean mShouldReturnDocumentImage;
     private boolean mShouldReturnSuccessfulImage;
     private boolean mShouldReturnFaceImage;
+
+    private static Map<String, Class<? extends BaseRecognitionResult>>
+            sFullDocumentImageResultTypes = new HashMap<>();
+
+    private static Map<String, Class<? extends BaseRecognitionResult>>
+            sFaceImageResultTypes = new HashMap<>();
 
     public BlinkIDModule(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -139,6 +148,7 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
         constants.put(RECOGNIZER_DOCUMENT_FACE_JS_KEY, RECOGNIZER_DOCUMENT_FACE);
         constants.put(RECOGNIZER_MYKAD_JS_KEY, RECOGNIZER_MYKAD);
         constants.put(RECOGNIZER_PDF417_JS_KEY, RECOGNIZER_PDF417);
+        constants.put(RECOGNIZER_NZDL_FRONT_JS_KEY, RECOGNIZER_NZDL_FRONT);
         return constants;
     }
 
@@ -151,7 +161,7 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
      *                        contact us at http://help.microblink.com
      * @param scanningOptions scanning options map with following key-value pairs:
      *                        {@Link #OPTION_USE_FRONT_CAMERA_JS_KEY} -> boolean
-     *                        {@link #OPTION_SHOULD_RETURN_CROPPED_IMAGE_JS_KEY} -> boolean
+     *                        {@link #OPTION_SHOULD_RETURN_DOCUMENT_IMAGE_JS_KEY} -> boolean
      *                        {@link #OPTION_SHOULD_RETURN_SUCCESSFUL_IMAGE_JS_KEY} -> boolean
      *                        {@link #RECOGNIZERS_ARRAY_JS_KEY} -> array of enabled recognizers
      * @param promise         Promise for returning scan results.
@@ -168,10 +178,12 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
         mScanPromise = promise;
 
         boolean useFrontCamera = readBooleanValue(scanningOptions, OPTION_USE_FRONT_CAMERA_JS_KEY, false);
-        mShouldReturnCroppedImage = readBooleanValue(scanningOptions, OPTION_SHOULD_RETURN_CROPPED_IMAGE_JS_KEY, false);
+        mShouldReturnDocumentImage = readBooleanValue(scanningOptions, OPTION_SHOULD_RETURN_DOCUMENT_IMAGE_JS_KEY, false);
         mShouldReturnSuccessfulImage = readBooleanValue(scanningOptions, OPTION_SHOULD_RETURN_SUCCESSFUL_IMAGE_JS_KEY, false);
         mShouldReturnFaceImage = readBooleanValue(scanningOptions, OPTION_SHOULD_RETURN_FACE_IMAGE_JS_KEY, false);
 
+        sFullDocumentImageResultTypes.clear();
+        sFaceImageResultTypes.clear();
         List<RecognizerSettings> recSettList = new ArrayList<>();
         if (scanningOptions.hasKey(RECOGNIZERS_ARRAY_JS_KEY)) {
             ReadableArray recognizerArray = scanningOptions.getArray(RECOGNIZERS_ARRAY_JS_KEY);
@@ -204,7 +216,7 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
 
         // set image metadata settings to define which images will be obtained as metadata during scan process
         MetadataSettings.ImageMetadataSettings ims = new MetadataSettings.ImageMetadataSettings();
-        if (mShouldReturnCroppedImage || mShouldReturnFaceImage) {
+        if (mShouldReturnDocumentImage || mShouldReturnFaceImage) {
             // enable obtaining of dewarped (cropped) images
             ims.setDewarpedImageEnabled(true);
         }
@@ -218,7 +230,7 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
         // pass image listener to scan activity
         scanIntent.putExtra(ScanCard.EXTRAS_IMAGE_LISTENER,
                 new ScanImageListener(
-                        mShouldReturnCroppedImage,
+                        mShouldReturnDocumentImage,
                         mShouldReturnSuccessfulImage,
                         mShouldReturnFaceImage
                 )
@@ -255,6 +267,8 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
                 return buildMyKadSettings();
             case RECOGNIZER_PDF417:
                 return buildPdf417Settings();
+            case RECOGNIZER_NZDL_FRONT:
+                return buildNzdlFrontSettings();
             default:
                 throw new IllegalArgumentException("Unknown recognizer type");
         }
@@ -273,7 +287,11 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
         // data quality when returning results.
         mrtd.setAllowUnparsedResults(false);
 
-        mrtd.setShowFullDocument(mShouldReturnCroppedImage);
+        if (mShouldReturnDocumentImage) {
+            mrtd.setShowFullDocument(true);
+            sFullDocumentImageResultTypes.put(MRTDRecognizerSettings.FULL_DOCUMENT_IMAGE,
+                    MRTDRecognitionResult.class);
+        }
 
         return mrtd;
     }
@@ -295,7 +313,7 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
         // increase recognition time. Default is true.
         usdl.setNullQuietZoneAllowed(true);
 
-        // USDLRecognizer does no return cropped image
+        // USDLRecognizer does no return full document nor face image
         return usdl;
     }
 
@@ -308,17 +326,24 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
         // To specify we want to perform EUDL (EU Driver's License) recognition,
         // prepare settings for EUDL recognizer. Pass country as parameter to EUDLRecognizerSettings
         // constructor. Here we choose AUTO - automatic country recognition.
-        EUDLRecognizerSettings ukdl = new EUDLRecognizerSettings(EUDLCountry.EUDL_COUNTRY_AUTO);
+        EUDLRecognizerSettings eudl = new EUDLRecognizerSettings(EUDLCountry.EUDL_COUNTRY_AUTO);
         // Defines if issue date should be extracted. Default is true
-        ukdl.setExtractIssueDate(true);
+        eudl.setExtractIssueDate(true);
         // Defines if expiry date should be extracted. Default is true.
-        ukdl.setExtractExpiryDate(true);
+        eudl.setExtractExpiryDate(true);
         // Defines if address should be extracted. Default is true.
-        ukdl.setExtractAddress(true);
-        if (mShouldReturnCroppedImage) {
-            ukdl.setShowFullDocument(true);
+        eudl.setExtractAddress(true);
+        if (mShouldReturnDocumentImage) {
+            sFullDocumentImageResultTypes.put(EUDLRecognizerSettings.FULL_DOCUMENT_IMAGE,
+                    EUDLRecognitionResult.class);
+            eudl.setShowFullDocument(true);
         }
-        return ukdl;
+        if (mShouldReturnFaceImage) {
+            sFaceImageResultTypes.put(EUDLRecognizerSettings.FACE_IMAGE_NAME,
+                    EUDLRecognitionResult.class);
+            eudl.setShowFaceImage(true);
+        }
+        return eudl;
     }
 
     /**
@@ -330,11 +355,15 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
         // prepare settings for Document Face recognizer
         // choose apropriate DocumentFaceDetectorType, here we use DocumentFaceDetectorType.IDENTITY_CARD_TD1
         DocumentFaceRecognizerSettings documentFace = new DocumentFaceRecognizerSettings(DocumentFaceDetectorType.IDENTITY_CARD_TD1);
-        if (mShouldReturnCroppedImage) {
+        if (mShouldReturnDocumentImage) {
             documentFace.setShowFullDocument(true);
+            sFullDocumentImageResultTypes.put(DocumentFaceRecognizerSettings.FULL_DOCUMENT_IMAGE,
+                    DocumentFaceRecognitionResult.class);
         }
         if (mShouldReturnFaceImage) {
             documentFace.setShowFaceImage(true);
+            sFaceImageResultTypes.put(DocumentFaceRecognizerSettings.FACE_IMAGE_NAME,
+                    DocumentFaceRecognitionResult.class);
         }
 
         return documentFace;
@@ -348,10 +377,38 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
     private MyKadFrontSideRecognizerSettings buildMyKadSettings() {
         // prepare settings for the MyKad (Malaysian ID card) recognizer
         MyKadFrontSideRecognizerSettings myKad = new MyKadFrontSideRecognizerSettings();
-        if (mShouldReturnCroppedImage) {
+        if (mShouldReturnDocumentImage) {
             myKad.setShowFullDocument(true);
+            sFullDocumentImageResultTypes.put(MyKadFrontSideRecognizerSettings.FULL_DOCUMENT_IMAGE,
+                    MyKadFrontSideRecognitionResult.class);
+        }
+        if (mShouldReturnFaceImage) {
+            myKad.setShowFaceImage(true);
+            sFaceImageResultTypes.put(MyKadFrontSideRecognizerSettings.FACE_IMAGE_NAME,
+                    MyKadFrontSideRecognitionResult.class);
         }
         return myKad;
+    }
+
+    /**
+     * Builds settings for the New Zealand Driver's license (front side) recognizer.
+     *
+     * @return settings for the New Zealand Driver's license (front side) recognizer.
+     */
+    private NewZealandDLFrontRecognizerSettings buildNzdlFrontSettings() {
+        // prepare settings for the New Zealand Driver's license (front side) recognizer
+        NewZealandDLFrontRecognizerSettings nzdl = new NewZealandDLFrontRecognizerSettings();
+        if (mShouldReturnDocumentImage) {
+            nzdl.setDisplayFullDocumentImage(true);
+            sFullDocumentImageResultTypes.put(NewZealandDLFrontRecognizerSettings.FULL_DOCUMENT_IMAGE,
+                    NewZealandDLFrontRecognitionResult.class);
+        }
+        if (mShouldReturnFaceImage) {
+            nzdl.setDisplayFaceImage(true);
+            sFaceImageResultTypes.put(NewZealandDLFrontRecognizerSettings.FACE_IMAGE_NAME,
+                    NewZealandDLFrontRecognitionResult.class);
+        }
+        return nzdl;
     }
 
     /**
@@ -384,12 +441,12 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
      */
     public static class ScanImageListener implements ImageListener {
 
-        private boolean mShouldStoreCroppedImage;
+        private boolean mShouldStoreDocumentImage;
         private boolean mShouldStoreSuccessfulImage;
         private boolean mShouldStoreFaceImage;
 
-        public ScanImageListener(boolean shouldStoreCroppedImage, boolean shouldStoreSuccessfulImage, boolean shouldStoreFaceImage) {
-            mShouldStoreCroppedImage = shouldStoreCroppedImage;
+        public ScanImageListener(boolean shouldStoreDocumentImage, boolean shouldStoreSuccessfulImage, boolean shouldStoreFaceImage) {
+            mShouldStoreDocumentImage = shouldStoreDocumentImage;
             mShouldStoreSuccessfulImage = shouldStoreSuccessfulImage;
             mShouldStoreFaceImage = shouldStoreFaceImage;
         }
@@ -399,14 +456,38 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
          */
         @Override
         public void onImageAvailable(Image image) {
-            ImageType imageType = image.getImageType();
-            if (mShouldStoreFaceImage && imageType == ImageType.DEWARPED && image.getImageName().equals(DocumentFaceRecognizerSettings.FACE_IMAGE_NAME)) {
-                ImageHolder.getInstance().setFaceImage(image.clone());
-            } else if (mShouldStoreCroppedImage && imageType == ImageType.DEWARPED) {
-                ImageHolder.getInstance().setDewarpedImage(image.clone());
-            } else if (mShouldStoreSuccessfulImage && imageType == ImageType.SUCCESSFUL_SCAN) {
-                ImageHolder.getInstance().setSuccessFulImage(image.clone());
+            switch (image.getImageType()) {
+                case DEWARPED:
+                    if (mShouldStoreFaceImage && storeFaceImage(image)) {
+                        return;
+                    } else if (mShouldStoreDocumentImage && storeDocumentImage(image)) {
+                        return;
+                    }
+                    break;
+                case SUCCESSFUL_SCAN:
+                    ImageHolder.getInstance().setSuccessfulImage(image.clone());
+                    break;
             }
+        }
+
+        private boolean storeFaceImage(Image image) {
+            String imageName = image.getImageName();
+            Class<? extends BaseRecognitionResult> resultType = sFaceImageResultTypes.get(imageName);
+            if (resultType != null) {
+                ImageHolder.getInstance().setFaceImage(resultType, image.clone());
+                return true;
+            }
+            return false;
+        }
+
+        private boolean storeDocumentImage(Image image) {
+            String imageName = image.getImageName();
+            Class<? extends BaseRecognitionResult> resultType = sFullDocumentImageResultTypes.get(imageName);
+            if (resultType != null) {
+                ImageHolder.getInstance().setDocumentImage(resultType, image.clone());
+                return true;
+            }
+            return false;
         }
 
         /**
@@ -420,7 +501,7 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
 
         @Override
         public void writeToParcel(Parcel dest, int flags) {
-            dest.writeByte(mShouldStoreCroppedImage ? (byte) 1 : 0);
+            dest.writeByte(mShouldStoreDocumentImage ? (byte) 1 : 0);
             dest.writeByte(mShouldStoreSuccessfulImage ? (byte) 1 : 0);
             dest.writeByte(mShouldStoreFaceImage ? (byte) 1 : 0);
         }
@@ -428,7 +509,11 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
         public static final Creator<ScanImageListener> CREATOR = new Creator<ScanImageListener>() {
             @Override
             public ScanImageListener createFromParcel(Parcel source) {
-                return new ScanImageListener(source.readByte() == 1, source.readByte() == 1, source.readByte() == 1);
+                return new ScanImageListener(
+                        source.readByte() == 1,
+                        source.readByte() == 1,
+                        source.readByte() == 1
+                );
             }
 
             @Override
@@ -438,59 +523,78 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
         };
     }
 
-    /**
-     * Holds obtained images.
-     */
     public static class ImageHolder {
 
         private static ImageHolder sInstance = new ImageHolder();
-        private Image mLastDewarpedImage = null;
-        private Image mSuccessFulImage = null;
-        private Image mFaceImage = null;
+        private Map<Class<? extends BaseRecognitionResult>, ImagesBundle> mImages;
+        private Image mLastSuccessfulImage;
 
         private ImageHolder() {
-
+            mImages = new HashMap<>();
         }
 
         public static ImageHolder getInstance() {
             return sInstance;
         }
 
-        public void setDewarpedImage(Image image) {
-            if (mLastDewarpedImage != null) {
-                mLastDewarpedImage.dispose();
-            }
-            mLastDewarpedImage = image;
+        public void setSuccessfulImage(Image image) {
+            mLastSuccessfulImage = image;
         }
 
-        public void setSuccessFulImage(Image image) {
-            if (mSuccessFulImage != null) {
-                mSuccessFulImage.dispose();
-            }
-            mSuccessFulImage = image;
+        public void setDocumentImage(Class<? extends BaseRecognitionResult> resultClass, Image image) {
+            getAndCreateBundle(resultClass).setDocumentImage(image);
         }
 
-        public Image getLastDewarpedImage() {
-            return mLastDewarpedImage;
+        public void setFaceImage(Class<? extends BaseRecognitionResult> resultClass, Image image) {
+            getAndCreateBundle(resultClass).setFaceImage(image);
+        }
+
+        private ImagesBundle getAndCreateBundle(Class<? extends BaseRecognitionResult> resultClass) {
+            ImagesBundle imagesBundle = mImages.get(resultClass);
+            if (imagesBundle == null) {
+                imagesBundle = new ImagesBundle();
+                mImages.put(resultClass, imagesBundle);
+            }
+            return imagesBundle;
+        }
+
+        public ImagesBundle getImages(Class<? extends BaseRecognitionResult> resultClass) {
+            return mImages.get(resultClass);
         }
 
         public Image getSuccessfulImage() {
-            return mSuccessFulImage;
+            return mLastSuccessfulImage;
         }
 
         public void clear() {
-            if (mLastDewarpedImage != null) {
-                mLastDewarpedImage.dispose();
+            for (ImagesBundle ib : mImages.values()) {
+                ib.dispose();
             }
-            if (mSuccessFulImage != null) {
-                mSuccessFulImage.dispose();
+            mImages.clear();
+            if (mLastSuccessfulImage != null) {
+                mLastSuccessfulImage.dispose();
+                mLastSuccessfulImage = null;
             }
-            if (mFaceImage != null) {
-                mFaceImage.dispose();
+        }
+    }
+
+    private static class ImagesBundle {
+        private Image mDocumentImage;
+        private Image mFaceImage;
+
+        public Image getDocumentImage() {
+            return mDocumentImage;
+        }
+
+        public void setDocumentImage(Image documentImage) {
+            if (mDocumentImage != null) {
+                mDocumentImage.dispose();
             }
-            mSuccessFulImage = null;
-            mLastDewarpedImage = null;
-            mFaceImage = null;
+            mDocumentImage = documentImage;
+        }
+
+        public Image getFaceImage() {
+            return mFaceImage;
         }
 
         public void setFaceImage(Image faceImage) {
@@ -500,8 +604,15 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
             mFaceImage = faceImage;
         }
 
-        public Image getFaceImage() {
-            return mFaceImage;
+        public void dispose() {
+            if (mDocumentImage != null) {
+                mDocumentImage.dispose();
+                mDocumentImage = null;
+            }
+            if (mFaceImage != null) {
+                mFaceImage.dispose();
+                mFaceImage = null;
+            }
         }
     }
 
@@ -545,6 +656,22 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
         return null;
     }
 
+    private void putImagesToResult(WritableMap resultMap, Class<? extends BaseRecognitionResult> resultType) {
+        ImagesBundle imagesBundle =  ImageHolder.getInstance().getImages(resultType);
+        WritableMap documentImageMap = null;
+        WritableMap faceImageMap = null;
+        if (imagesBundle != null) {
+            documentImageMap = exportImage(imagesBundle.getDocumentImage());
+            faceImageMap = exportImage(imagesBundle.getFaceImage());
+        }
+        if (documentImageMap != null) {
+            resultMap.putMap(RESULT_IMAGE_DOCUMENT, documentImageMap);
+        }
+        if (faceImageMap != null) {
+            resultMap.putMap(RESULT_IMAGE_FACE, faceImageMap);
+        }
+    }
+
     /**
      * Builds USDL result for returning to JS.
      *
@@ -552,7 +679,7 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
      * @return map representation of the given {@code res} for returning to JS.
      */
     private WritableMap buildUSDLResult(USDLScanResult res) {
-        return buildKeyValueResult(res, USDL_RESULT_TYPE);
+        return buildNativeKeyValueResult(res, USDL_RESULT_TYPE);
     }
 
     /**
@@ -562,7 +689,9 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
      * @return map representation of the given {@code res} for returning to JS.
      */
     private WritableMap buildEUDLResult(EUDLRecognitionResult res) {
-        return buildKeyValueResult(res, EUDL_RESULT_TYPE);
+        WritableMap result = buildNativeKeyValueResult(res, EUDL_RESULT_TYPE);
+        putImagesToResult(result, EUDLRecognitionResult.class);
+        return result;
     }
 
     /**
@@ -572,7 +701,9 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
      * @return map representation of the given {@code res} for returning to JS.
      */
     private WritableMap buildMRTDResult(MRTDRecognitionResult res) {
-        return buildKeyValueResult(res, MRTD_RESULT_TYPE);
+        WritableMap result = buildNativeKeyValueResult(res, MRTD_RESULT_TYPE);
+        putImagesToResult(result, MRTDRecognitionResult.class);
+        return result;
     }
 
     /**
@@ -582,10 +713,8 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
      * @return map representation of the given {@code res} for returning to JS.
      */
     private WritableMap buildDocumentFaceResult(DocumentFaceRecognitionResult res) {
-        WritableMap fields = new WritableNativeMap();
-        WritableMap result = new WritableNativeMap();
-        result.putString(RESULT_TYPE, DOCUMENT_FACE_RESULT_TYPE);
-        result.putMap(FIELDS, fields);
+        WritableMap result = buildResult(DOCUMENT_FACE_RESULT_TYPE, new WritableNativeMap());
+        putImagesToResult(result, DocumentFaceRecognitionResult.class);
         return result;
     }
 
@@ -596,7 +725,24 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
      * @return map representation of the given {@code res} for returning to JS.
      */
     private WritableMap buildMyKadResult(MyKadFrontSideRecognitionResult res) {
-        return buildKeyValueResult(res, MYKAD_RESULT_TYPE);
+        WritableMap result = buildNativeKeyValueResult(res, MYKAD_RESULT_TYPE);
+        putImagesToResult(result, MyKadFrontSideRecognitionResult.class);
+        return result;
+    }
+
+    /**
+     * Builds New Zealand DL front result for returning to JS.
+     *
+     * @param res New Zealand DL front result.
+     * @return map representation of the given {@code res} for returning to JS.
+     */
+    private WritableMap buildNewZealandDLFrontResult(NewZealandDLFrontRecognitionResult res) {
+        WritableMap resultFields = buildFieldsMapFromNativeResult(res);
+        resultFields.putBoolean("NewZealandDLDonorIndicator.DonorIndicator", res.getDonorIndicator());
+
+        WritableMap result = buildResult(NZDL_FRONT_RESULT_TYPE, resultFields);
+        putImagesToResult(result, NewZealandDLFrontRecognitionResult.class);
+        return result;
     }
 
     /**
@@ -606,10 +752,21 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
      * @return map representation of the given {@code res} for returning to JS.
      */
     private WritableMap buildPDF417Result(Pdf417ScanResult res) {
-        return buildKeyValueResult(res, PDF417_RESULT_TYPE);
+        return buildNativeKeyValueResult(res, PDF417_RESULT_TYPE);
     }
 
-    private WritableMap buildKeyValueResult(BaseRecognitionResult res, String resultType) {
+    private WritableMap buildResult(String resultType, WritableMap fieldsMap) {
+        WritableMap result = new WritableNativeMap();
+        result.putString(RESULT_TYPE, resultType);
+        result.putMap(FIELDS, fieldsMap);
+        return result;
+    }
+
+    private WritableMap buildNativeKeyValueResult(BaseRecognitionResult res, String resultType) {
+        return buildResult(resultType, buildFieldsMapFromNativeResult(res));
+    }
+
+    private WritableMap buildFieldsMapFromNativeResult(BaseRecognitionResult res) {
         WritableMap fields = new WritableNativeMap();
         IResultHolder resultHolder = res.getResultHolder();
         for (String key : resultHolder.keySet()) {
@@ -622,10 +779,7 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
                 Log.d(LOG_TAG, "Ignoring result key '" + key + "'");
             }
         }
-        WritableMap result = new WritableNativeMap();
-        result.putString(RESULT_TYPE, resultType);
-        result.putMap(FIELDS, fields);
-        return result;
+        return fields;
     }
 
     private final ActivityEventListener mScanActivityListener = new BaseActivityEventListener() {
@@ -655,6 +809,8 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
                                 resultsList.pushMap(buildDocumentFaceResult((DocumentFaceRecognitionResult) res));
                             } else if (res instanceof MyKadFrontSideRecognitionResult) { // check if scan result is result of MyKad recognizer
                                 resultsList.pushMap(buildMyKadResult((MyKadFrontSideRecognitionResult) res));
+                            } else if (res instanceof NewZealandDLFrontRecognitionResult) {
+                                resultsList.pushMap(buildNewZealandDLFrontResult((NewZealandDLFrontRecognitionResult) res));
                             } else if (res instanceof Pdf417ScanResult) { // check if scan result is result of PDF417 recognizer
                                 resultsList.pushMap(buildPDF417Result((Pdf417ScanResult) res));
                             }
@@ -662,32 +818,13 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
 
                         WritableMap root = new WritableNativeMap();
                         root.putArray(RESULT_LIST, resultsList);
-
-                        WritableMap images = new WritableNativeMap();
-                        if (mShouldReturnCroppedImage) {
-                            Image image = ImageHolder.getInstance().getLastDewarpedImage();
-                            WritableMap map = exportImage(image);
-                            if (map != null) {
-                                images.putMap(RESULT_IMAGE_CROPPED, map);
-                            }
-                        }
                         if (mShouldReturnSuccessfulImage) {
-                            Image image = ImageHolder.getInstance().getSuccessfulImage();
-                            WritableMap map = exportImage(image);
-                            if (map != null) {
-                                images.putMap(RESULT_IMAGE_SUCCESSFUL, map);
+                            Image successfulImage = ImageHolder.getInstance().getSuccessfulImage();
+                            WritableMap successfulImageMap = exportImage(successfulImage);
+                            if (successfulImageMap != null) {
+                                root.putMap(RESULT_IMAGE_SUCCESSFUL, successfulImageMap);
                             }
                         }
-                        if (mShouldReturnFaceImage) {
-                            Image image = ImageHolder.getInstance().getFaceImage();
-                            WritableMap map = exportImage(image);
-                            if (map != null) {
-                                images.putMap(RESULT_IMAGE_FACE, map);
-                            }
-                        }
-
-                        root.putMap(RESULT_IMAGES, images);
-
                         mScanPromise.resolve(root);
                     } else if (resultCode == ScanCard.RESULT_CANCELED) {
                         rejectPromise(STATUS_SCAN_CANCELED, "Scanning has been canceled");
@@ -699,14 +836,16 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
         }
     };
 
-    private WritableMap exportImage (Image image) {
-        WritableMap info = new WritableNativeMap();
+    private WritableMap exportImage(Image image) {
+        WritableMap imageMap = new WritableNativeMap();
         String base64 = convertImageToJPEGBase64Encoded(image);
-        if (base64 == null) return null;
-
-        info.putString("base64", base64);
-        info.putInt("width", image.getWidth());
-        info.putInt("height", image.getHeight());
-        return info;
+        if (base64 == null) {
+            return null;
+        }
+        imageMap.putString("base64", base64);
+        imageMap.putInt("width", image.getWidth());
+        imageMap.putInt("height", image.getHeight());
+        return imageMap;
     }
+
 }

--- a/src/android/src/main/java/com/microblink/reactnative/blinkid/BlinkIDModule.java
+++ b/src/android/src/main/java/com/microblink/reactnative/blinkid/BlinkIDModule.java
@@ -201,6 +201,7 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
         // default is false, which means that as soon as first barcode is found (no matter which type)
         // its contents will be returned.
         recognitionSettings.setAllowMultipleScanResultsOnSingleImage(true);
+        recognitionSettings.setNumMsBeforeTimeout(60_000);
 
         // create scan intent fore ScanCard activity
         Intent scanIntent = new Intent(currentActivity, ScanCard.class);
@@ -641,18 +642,18 @@ public class BlinkIDModule extends ReactContextBaseJavaModule {
         if (image == null) {
             return null;
         }
-        Bitmap imageBmp = image.convertToBitmap();
-        if (imageBmp != null) {
-            ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-            boolean success = imageBmp.compress(Bitmap.CompressFormat.JPEG, COMPRESSED_IMAGE_QUALITY, byteArrayOutputStream);
-            if (success) {
-                return Base64.encodeToString(byteArrayOutputStream.toByteArray(), Base64.DEFAULT);
-            }
-            try {
+        try {
+            Bitmap imageBmp = image.convertToBitmap();
+            if (imageBmp != null) {
+                ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+                boolean success = imageBmp.compress(Bitmap.CompressFormat.JPEG, COMPRESSED_IMAGE_QUALITY, byteArrayOutputStream);
+                if (success) {
+                    return Base64.encodeToString(byteArrayOutputStream.toByteArray(), Base64.DEFAULT);
+                }
                 byteArrayOutputStream.close();
-            } catch (IOException ignorable) {
             }
-        }
+
+        } catch (Exception ignore) {}
         return null;
     }
 

--- a/src/ios/BlinkIDReactNative/BlinkIDReactNative/BlinkIDReactNative.mm
+++ b/src/ios/BlinkIDReactNative/BlinkIDReactNative/BlinkIDReactNative.mm
@@ -11,7 +11,15 @@
 #import <React/RCTConvert.h>
 #import <MicroBlink/MicroBlink.h>
 
+typedef NS_ENUM(NSUInteger, PPImageType) {
+    PPImageTypeFace,
+    PPImageTypeDocument,
+    PPImageTypeSuccessful,
+};
+
 @interface BlinkIDReactNative () <PPScanningDelegate>
+
+@property (nonatomic) NSMutableDictionary<NSString *, NSMutableDictionary *> *imageMetadatas;
 
 @property (nonatomic, assign) BOOL enableBeep;
 
@@ -25,15 +33,11 @@
 
 @property (nonatomic, strong) NSString* licenseKey;
 
-@property (nonatomic) UIImage *scannedImageDewarped;
-
-@property (nonatomic) UIImage *scannedImageSuccesful;
-
-@property (nonatomic) UIImage *scannedImageFace;
+@property (nonatomic) PPImageMetadata *scannedImageSuccesful;
 
 @property (nonatomic, strong) NSArray *recognizers;
 
-@property (nonatomic) BOOL shouldReturnCroppedImage;
+@property (nonatomic) BOOL shouldReturnDocumentImage;
 
 @property (nonatomic) BOOL shouldReturnSuccessfulImage;
 
@@ -49,34 +53,35 @@ static NSString* const kStatusScanCanceled = @"STATUS_SCAN_CANCELED";
 // js keys for scanning options
 static NSString* const kOptionEnableBeepKey = @"enableBeep";
 static NSString* const kOptionUseFrontCameraJsKey = @"useFrontCamera";
-static NSString* const kOptionReturnCroppedImageJsKey = @"shouldReturnCroppedImage";
+static NSString* const kOptionReturnDocumentImageJsKey = @"shouldReturnDocumentImage";
 static NSString* const kOptionShouldReturnSuccessfulImageJsKey = @"shouldReturnSuccessfulImage";
 static NSString* const kOptionReturnFaceImageJsKey = @"shouldReturnFaceImage";
-static NSString* const kOptionQuality = @"quality";
 static NSString* const kRecognizersArrayJsKey = @"recognizers";
 
 // js keys for recognizer types
-static NSString* const kRecognizerMRTDJsKey = @"RECOGNIZER_MRTD";
 static NSString* const kRecognizerUSDLJsKey = @"RECOGNIZER_USDL";
+static NSString* const kRecognizerMRTDJsKey = @"RECOGNIZER_MRTD";
 static NSString* const kRecognizerEUDLJsKey = @"RECOGNIZER_EUDL";
 static NSString* const kRecognizerMyKadJsKey = @"RECOGNIZER_MYKAD";
+static NSString* const kRecognizerNZDLFrontJsKey = @"RECOGNIZER_NZDL_FRONT";
 static NSString* const kRecognizerDocumentFaceJsKey = @"RECOGNIZER_DOCUMENT_FACE";
 static NSString* const kRecognizerPDF417JsKey = @"RECOGNIZER_PDF417";
 
 // js result keys
 static NSString* const kResultList = @"resultList";
 static NSString* const kResultImages = @"images";
-static NSString* const kResultImageCropped = @"cropped";
+static NSString* const kResultImageDocument = @"resultImageDocument";
 static NSString* const kResultImageSuccessful = @"successful";
-static NSString* const kResultImageFace = @"face";
+static NSString* const kResultImageFace = @"resultImageFace";
 static NSString* const kResultType = @"resultType";
 static NSString* const kFields = @"fields";
 
 // result values for resultType
-static NSString* const kMRTDResultType = @"MRTD result";
 static NSString* const kUSDLResultType = @"USDL result";
+static NSString* const kMRTDResultType = @"MRTD result";
 static NSString* const kEUDLResultType = @"EUDL result";
 static NSString* const kMyKadResultType = @"MyKad result";
+static NSString* const kNZDLFrontResultType = @"NZDLFront result";
 static NSString* const kDocumentFaceResultType = @"DocumentFace result";
 static NSString* const kPDF417ResultType = @"PDF417 result";
 
@@ -85,6 +90,18 @@ static NSString* const kRaw = @"raw";
 static NSString* const kMRTDDateOfBirth = @"DateOfBirth";
 static NSString* const kMRTDDateOExpiry = @"DateOfExpiry";
 static NSString* const kMyKadBirthDate = @"ownerBirthDate";
+static NSString* const kNZDLFrontDonorIndicator = @"NewZealandDLDonorIndicator.DonorIndicator";
+static NSString* const kNZDLFrontDateOfBirth = @"NewZealandDLDateOfBirth.DateOfBirth";
+static NSString* const kNZDLFrontExpiryDate = @"NewZealandDLExpiryDate.ExpiryDate";
+static NSString* const kNZDLFrontIssueDate = @"NewZealandDLIssueDate.IssueDate";
+
+// image result keys
+static NSString* const kWidth = @"width";
+static NSString* const kHeight = @"height";
+static NSString* const kBase64 = @"base64";
+
+// date conversion keys
+static NSString* const kNZDLDateFormat = @"dd-MM-yyyy";
 
 // NSError Domain
 static NSString* const MBErrorDomain = @"microblink.error";
@@ -106,11 +123,13 @@ RCT_EXPORT_MODULE();
     [constants setObject:@"RECOGNIZER_EUDL" forKey:kRecognizerEUDLJsKey];
     [constants setObject:@"RECOGNIZER_DOCUMENT_FACE" forKey:kRecognizerDocumentFaceJsKey];
     [constants setObject:@"RECOGNIZER_MYKAD" forKey:kRecognizerMyKadJsKey];
+    [constants setObject:@"RECOGNIZER_NZDL_FRONT" forKey:kRecognizerNZDLFrontJsKey];
     [constants setObject:@"RECOGNIZER_PDF417" forKey:kRecognizerPDF417JsKey];
-    [constants setObject:@"MRTD result" forKey:kMRTDResultType];
     [constants setObject:@"USDL result" forKey:kUSDLResultType];
+    [constants setObject:@"MRTD result" forKey:kMRTDResultType];
     [constants setObject:@"EUDL result" forKey:kEUDLResultType];
     [constants setObject:@"MyKad result" forKey:kMyKadResultType];
+    [constants setObject:@"NZDLFront result" forKey:kNZDLFrontResultType];
     [constants setObject:@"PDF417 result" forKey:kPDF417ResultType];
     [constants setObject:@"DocumentFace result" forKey:kDocumentFaceResultType];
     return [NSDictionary dictionaryWithDictionary:constants];
@@ -131,7 +150,7 @@ RCT_REMAP_METHOD(scan, scan:(NSString *)key withOptions:(NSDictionary*)scanOptio
     else {
         self.licenseKey = key;
     }
-    
+
     BOOL isFrontCamera = [[scanOptions valueForKey:kOptionUseFrontCameraJsKey] boolValue];
     if (!isFrontCamera) {
         self.cameraType = PPCameraTypeBack;
@@ -143,14 +162,14 @@ RCT_REMAP_METHOD(scan, scan:(NSString *)key withOptions:(NSDictionary*)scanOptio
 
     self.promiseResolve = resolve;
     self.promiseReject  = reject;
-    
+
     self.options = scanOptions;
     self.recognizers = [scanOptions valueForKey:kRecognizersArrayJsKey];
-    
+
     /** Instantiate the scanning coordinator */
     NSError *error;
     PPCameraCoordinator *coordinator = [self coordinatorWithError:&error];
-    
+
     /** If scanning isn't supported, present an error */
     if (coordinator == nil) {
         NSDictionary *userInfo = @{
@@ -162,22 +181,22 @@ RCT_REMAP_METHOD(scan, scan:(NSString *)key withOptions:(NSDictionary*)scanOptio
                                              code:-57
                                          userInfo:userInfo];
         reject(kErrorCoordniatorDoesNotExists, @"Coordinator does not exists", error);
-        
+
         return;
     }
-    
+
     /** Allocate and present the scanning view controller */
     UIViewController<PPScanningViewController>* scanningViewController = [PPViewControllerFactory cameraViewControllerWithDelegate:self coordinator:coordinator error:nil];
-    
+
     // allow rotation if VC is displayed as a modal view controller
     scanningViewController.autorotate = YES;
     scanningViewController.supportedOrientations = UIInterfaceOrientationMaskAll;
-    
+
     UIViewController *rootViewController = [[[UIApplication sharedApplication] keyWindow] rootViewController];
     dispatch_sync(dispatch_get_main_queue(), ^{
         [rootViewController presentViewController:scanningViewController animated:YES completion:nil];
     });
-    
+
 }
 
 #pragma mark - BlinkID specifics
@@ -192,17 +211,19 @@ RCT_REMAP_METHOD(scan, scan:(NSString *)key withOptions:(NSDictionary*)scanOptio
  */
 - (PPCameraCoordinator *)coordinatorWithError:(NSError**)error {
     /** 0. Check if scanning is supported */
-    
+
     if ([PPCameraCoordinator isScanningUnsupportedForCameraType:self.cameraType error:error]) {
         return nil;
     }
-    
+
     /** 1. Initialize the Scanning settings */
-    
+
     // Initialize the scanner settings object. This initialize settings with all default values.
     PPSettings *settings = [[PPSettings alloc] init];
-    
-    self.shouldReturnCroppedImage = NO;
+
+    self.imageMetadatas = [[NSMutableDictionary alloc] init];
+
+    self.shouldReturnDocumentImage = NO;
     self.shouldReturnSuccessfulImage = NO;
     self.shouldReturnFaceImage = NO;
 
@@ -210,10 +231,10 @@ RCT_REMAP_METHOD(scan, scan:(NSString *)key withOptions:(NSDictionary*)scanOptio
         settings.metadataSettings.successfulFrame = YES;
         self.shouldReturnSuccessfulImage = YES;
     }
-    
-    if ([[self.options valueForKey:kOptionReturnCroppedImageJsKey] boolValue]) {
+
+    if ([[self.options valueForKey:kOptionReturnDocumentImageJsKey] boolValue]) {
         settings.metadataSettings.dewarpedImage = YES;
-        self.shouldReturnCroppedImage = YES;
+        self.shouldReturnDocumentImage = YES;
     }
 
     if ([[self.options valueForKey:kOptionReturnFaceImageJsKey] boolValue]) {
@@ -222,11 +243,9 @@ RCT_REMAP_METHOD(scan, scan:(NSString *)key withOptions:(NSDictionary*)scanOptio
     }
 
     settings.cameraSettings.cameraType = self.cameraType;
-    
-    self.scannedImageDewarped = nil;
+
     self.scannedImageSuccesful = nil;
-    self.scannedImageFace = nil;
-    
+
     // Do not timeout
     settings.scanSettings.partialRecognitionTimeout = 0.0f;
 
@@ -234,32 +253,36 @@ RCT_REMAP_METHOD(scan, scan:(NSString *)key withOptions:(NSDictionary*)scanOptio
 
     // Visit www.microblink.com to get the license key for your app
     settings.licenseSettings.licenseKey = self.licenseKey;
-    
-    
+
+
     /** 3. Set up what is being scanned. See detailed guides for specific use cases. */
-    
+
     /**
      * Add all needed recognizers
      */
-    
+
     if ([self shouldUseUsdlRecognizer]) {
         [settings.scanSettings addRecognizerSettings:[self usdlRecognizerSettings]];
     }
-    
+
     if ([self shouldUseMrtdRecognizer]) {
         [settings.scanSettings addRecognizerSettings:[self mrtdRecognizerSettings]];
     }
-    
+
     if ([self shouldUseEudlRecognizer]) {
         [settings.scanSettings addRecognizerSettings:[self eudlRecognizerSettingsWithCountry:PPEudlCountryAny]];
     }
-    
+
     if ([self shouldUseDocumentFaceRecognizer]) {
         [settings.scanSettings addRecognizerSettings:[self documentFaceRecognizerSettings]];
     }
-    
+
     if ([self shouldUseMyKadRecognizer]) {
         [settings.scanSettings addRecognizerSettings:[self myKadRecognizerSettings]];
+    }
+
+    if ([self shouldUseNzdlFrontRecognizer]) {
+        [settings.scanSettings addRecognizerSettings:[self nzdlFrontRecognizerSettings]];
     }
 
     if ([self shouldUsePDF417Recognizer]) {
@@ -267,9 +290,9 @@ RCT_REMAP_METHOD(scan, scan:(NSString *)key withOptions:(NSDictionary*)scanOptio
     }
 
     /** 4. Initialize the Scanning Coordinator object */
-    
+
     PPCameraCoordinator *coordinator = [[PPCameraCoordinator alloc] initWithSettings:settings];
-    
+
     return coordinator;
 }
 
@@ -300,22 +323,29 @@ RCT_REMAP_METHOD(scan, scan:(NSString *)key withOptions:(NSDictionary*)scanOptio
     // Check if metadata obtained is image. You can set what type of image is outputed by setting different properties of PPMetadataSettings (currently, dewarpedImage is set at line 207)
     if ([metadata isKindOfClass:[PPImageMetadata class]]) {
         PPImageMetadata *imageMetadata = (PPImageMetadata *)metadata;
-        PPImageMetadataType imageMetadataType = imageMetadata.imageType;
-        if (imageMetadataType == PPImageMetadataTypeDewarpedImage && self.shouldReturnFaceImage == YES && [imageMetadata.name isEqualToString:[PPDocumentFaceRecognizerSettings ID_FACE]]) {
-            self.scannedImageFace = imageMetadata.image;
-        }
-        else if (imageMetadataType == PPImageMetadataTypeDewarpedImage && self.shouldReturnCroppedImage == YES) {
-            self.scannedImageDewarped = imageMetadata.image;
-        }
-        else if (imageMetadataType == PPImageMetadataTypeSuccessfulFrame && self.shouldReturnSuccessfulImage == YES) {
-            self.scannedImageSuccesful = imageMetadata.image;
+
+        if ([imageMetadata imageType] == PPImageMetadataTypeSuccessfulFrame && self.shouldReturnSuccessfulImage) {
+            self.scannedImageSuccesful = imageMetadata;
+
+        } else if ([imageMetadata imageType] == PPImageMetadataTypeDewarpedImage) {
+
+            [self setImageMetadata:imageMetadata forName:[PPMrtdRecognizerSettings FULL_DOCUMENT_IMAGE] imageType:PPImageTypeDocument resultClass:[PPMrtdRecognizerResult class]];
+            [self setImageMetadata:imageMetadata forName:[PPEudlRecognizerSettings FULL_DOCUMENT_IMAGE] imageType:PPImageTypeDocument resultClass:[PPEudlRecognizerResult class]];
+            [self setImageMetadata:imageMetadata forName:[PPMyKadFrontRecognizerSettings FULL_DOCUMENT_IMAGE] imageType:PPImageTypeDocument resultClass:[PPMyKadFrontRecognizerResult class]];
+            [self setImageMetadata:imageMetadata forName:[PPNewZealandDLFrontRecognizerSettings FULL_DOCUMENT_IMAGE] imageType:PPImageTypeDocument resultClass:[PPNewZealandDLFrontRecognizerResult class]];
+            [self setImageMetadata:imageMetadata forName:[PPDocumentFaceRecognizerSettings FULL_DOCUMENT_IMAGE] imageType:PPImageTypeDocument resultClass:[PPDocumentFaceRecognizerResult class]];
+
+            [self setImageMetadata:imageMetadata forName:[PPEudlRecognizerSettings ID_FACE] imageType:PPImageTypeFace resultClass:[PPEudlRecognizerResult class]];
+            [self setImageMetadata:imageMetadata forName:[PPMyKadFrontRecognizerSettings ID_FACE] imageType:PPImageTypeFace resultClass:[PPMyKadFrontRecognizerResult class]];
+            [self setImageMetadata:imageMetadata forName:[PPNewZealandDLFrontRecognizerSettings ID_FACE] imageType:PPImageTypeFace resultClass:[PPNewZealandDLFrontRecognizerResult class]];
+            [self setImageMetadata:imageMetadata forName:[PPDocumentFaceRecognizerSettings ID_FACE] imageType:PPImageTypeFace resultClass:[PPDocumentFaceRecognizerResult class]];
         }
     }
 }
 
 - (void)scanningViewController:(UIViewController<PPScanningViewController> *)scanningViewController
               didOutputResults:(NSArray<PPRecognizerResult*> *)results {
-    
+
     // Here you process scanning results. Scanning results are given in the array of PPRecognizerResult objects.
     // first, pause scanning until we process all the results
     [scanningViewController pauseScanning];
@@ -348,19 +378,23 @@ RCT_REMAP_METHOD(scan, scan:(NSString *)key withOptions:(NSDictionary*)scanOptio
     return [self.recognizers containsObject:kRecognizerEUDLJsKey];
 }
 
-- (BOOL)shouldUseDocumentFaceRecognizer {
-    return [self.recognizers containsObject:kRecognizerDocumentFaceJsKey];
-}
-
 - (BOOL)shouldUseMyKadRecognizer {
     return [self.recognizers containsObject:kRecognizerMyKadJsKey];
+}
+
+- (BOOL)shouldUseNzdlFrontRecognizer {
+    return [self.recognizers containsObject:kRecognizerNZDLFrontJsKey];
+}
+
+- (BOOL)shouldUseDocumentFaceRecognizer {
+    return [self.recognizers containsObject:kRecognizerDocumentFaceJsKey];
 }
 
 - (BOOL)shouldUsePDF417Recognizer {
     return [self.recognizers containsObject:kRecognizerPDF417JsKey];
 }
 
-#pragma mark - Utils
+#pragma mark - RecognizerResults
 
 - (void)setDictionary:(NSMutableDictionary *)dict withUsdlResult:(PPUsdlRecognizerResult *)usdlResult {
     [dict setObject:[usdlResult getAllStringElements] forKey:kFields];
@@ -374,16 +408,13 @@ RCT_REMAP_METHOD(scan, scan:(NSString *)key withOptions:(NSDictionary*)scanOptio
     [dict setObject:stringElements forKey:kFields];
     [dict setObject:[mrtdResult mrzText] forKey:kRaw];
     [dict setObject:kMRTDResultType forKey:kResultType];
+    [self setupDictionary:dict withImagesForResult:mrtdResult];
 }
 
 - (void)setDictionary:(NSMutableDictionary *)dict withEudlRecognizerResult:(PPEudlRecognizerResult *)eudlResult {
     [dict setObject:[eudlResult getAllStringElements] forKey:kFields];
     [dict setObject:kEUDLResultType forKey:kResultType];
-}
-
-- (void)setDictionary:(NSMutableDictionary *)dict withDocumentFaceResult:(PPDocumentFaceRecognizerResult *)documentFaceResult {
-    [dict setObject:[documentFaceResult getAllStringElements] forKey:kFields];
-    [dict setObject:kDocumentFaceResultType forKey:kResultType];
+    [self setupDictionary:dict withImagesForResult:eudlResult];
 }
 
 - (void)setDictionary:(NSMutableDictionary *)dict withMyKadRecognizerResult:(PPMyKadFrontRecognizerResult *)myKadResult {
@@ -391,6 +422,36 @@ RCT_REMAP_METHOD(scan, scan:(NSString *)key withOptions:(NSDictionary*)scanOptio
     [stringElements setObject:myKadResult.rawOwnerBirthDate forKey:kMyKadBirthDate];
     [dict setObject:stringElements forKey:kFields];
     [dict setObject:kMyKadResultType forKey:kResultType];
+    [self setupDictionary:dict withImagesForResult:myKadResult];
+}
+
+- (void)setDictionary:(NSMutableDictionary *)dict withNzdlFrontResult:(PPNewZealandDLFrontRecognizerResult *)nzdlFrontResult {
+    NSMutableDictionary *stringElements = [NSMutableDictionary dictionaryWithDictionary:[nzdlFrontResult getAllStringElements]];
+    [stringElements setObject:@([nzdlFrontResult donorIndicator]) forKey:kNZDLFrontDonorIndicator];
+
+    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+    dateFormatter.dateFormat = kNZDLDateFormat;
+    dateFormatter.timeZone = [NSTimeZone systemTimeZone];
+
+    if (nzdlFrontResult.dateOfBirth) {
+        [stringElements setObject:[dateFormatter stringFromDate:[nzdlFrontResult dateOfBirth]] forKey:kNZDLFrontDateOfBirth];
+    }
+    if (nzdlFrontResult.issueDate) {
+        [stringElements setObject:[dateFormatter stringFromDate:[nzdlFrontResult issueDate]] forKey:kNZDLFrontIssueDate];
+    }
+    if (nzdlFrontResult.expiryDate) {
+        [stringElements setObject:[dateFormatter stringFromDate:[nzdlFrontResult expiryDate]] forKey:kNZDLFrontExpiryDate];
+    }
+
+    [dict setObject:stringElements forKey:kFields];
+    [dict setObject:kNZDLFrontResultType forKey:kResultType];
+    [self setupDictionary:dict withImagesForResult:nzdlFrontResult];
+}
+
+- (void)setDictionary:(NSMutableDictionary *)dict withDocumentFaceResult:(PPDocumentFaceRecognizerResult *)documentFaceResult {
+    [dict setObject:[documentFaceResult getAllStringElements] forKey:kFields];
+    [dict setObject:kDocumentFaceResultType forKey:kResultType];
+    [self setupDictionary:dict withImagesForResult:documentFaceResult];
 }
 
 - (void)setDictionary:(NSMutableDictionary *)dict withPdf417Result:(PPPdf417RecognizerResult *)pdf417Result {
@@ -402,51 +463,60 @@ RCT_REMAP_METHOD(scan, scan:(NSString *)key withOptions:(NSDictionary*)scanOptio
     NSMutableDictionary *resultDict = [[NSMutableDictionary alloc] init];
 
     NSMutableArray *resultArray = [[NSMutableArray alloc] init];
-    
+
     for (PPRecognizerResult *result in results) {
-        
+
         if ([result isKindOfClass:[PPUsdlRecognizerResult class]]) {
             PPUsdlRecognizerResult *usdlResult = (PPUsdlRecognizerResult *)result;
-            
+
             NSMutableDictionary *dict = [[NSMutableDictionary alloc] init];
             [self setDictionary:dict withUsdlResult:usdlResult];
-            
+
             [resultArray addObject:dict];
         }
-        
+
         if ([result isKindOfClass:[PPMrtdRecognizerResult class]]) {
             PPMrtdRecognizerResult *mrtdDecoderResult = (PPMrtdRecognizerResult *)result;
-            
+
             NSMutableDictionary *dict = [[NSMutableDictionary alloc] init];
             [self setDictionary:dict withMrtdRecognizerResult:mrtdDecoderResult];
-            
+
             [resultArray addObject:dict];
         }
-        
+
         if ([result isKindOfClass:[PPEudlRecognizerResult class]]) {
             PPEudlRecognizerResult *eudlDecoderResult = (PPEudlRecognizerResult *)result;
-            
+
             NSMutableDictionary *dict = [[NSMutableDictionary alloc] init];
             [self setDictionary:dict withEudlRecognizerResult:eudlDecoderResult];
-            
+
             [resultArray addObject:dict];
         }
-        
-        if ([result isKindOfClass:[PPDocumentFaceRecognizerResult class]]) {
-            PPDocumentFaceRecognizerResult *documentFaceResult = (PPDocumentFaceRecognizerResult *)result;
-            
-            NSMutableDictionary *dict = [[NSMutableDictionary alloc] init];
-            [self setDictionary:dict withDocumentFaceResult:documentFaceResult];
-            
-            [resultArray addObject:dict];
-        }
-        
+
         if ([result isKindOfClass:[PPMyKadFrontRecognizerResult class]]) {
             PPMyKadFrontRecognizerResult *myKadDecoderResult = (PPMyKadFrontRecognizerResult *)result;
-            
+
             NSMutableDictionary *dict = [[NSMutableDictionary alloc] init];
             [self setDictionary:dict withMyKadRecognizerResult:myKadDecoderResult];
-            
+
+            [resultArray addObject:dict];
+        }
+
+        if ([result isKindOfClass:[PPNewZealandDLFrontRecognizerResult class]]) {
+            PPNewZealandDLFrontRecognizerResult *nzdlFrontResult = (PPNewZealandDLFrontRecognizerResult *)result;
+
+            NSMutableDictionary *dict = [[NSMutableDictionary alloc] init];
+            [self setDictionary:dict withNzdlFrontResult:nzdlFrontResult];
+
+            [resultArray addObject:dict];
+        }
+
+        if ([result isKindOfClass:[PPDocumentFaceRecognizerResult class]]) {
+            PPDocumentFaceRecognizerResult *documentFaceResult = (PPDocumentFaceRecognizerResult *)result;
+
+            NSMutableDictionary *dict = [[NSMutableDictionary alloc] init];
+            [self setDictionary:dict withDocumentFaceResult:documentFaceResult];
+
             [resultArray addObject:dict];
         }
 
@@ -459,156 +529,279 @@ RCT_REMAP_METHOD(scan, scan:(NSString *)key withOptions:(NSDictionary*)scanOptio
             [resultArray addObject:dict];
         }
     }
-    
+
     if ([resultArray count] > 0) {
         [resultDict setObject:resultArray forKey:kResultList];
     }
 
-    NSMutableDictionary* images = [NSMutableDictionary dictionary];
-    if (self.scannedImageDewarped && self.shouldReturnCroppedImage) {
-        [images setObject:[self exportImage:self.scannedImageDewarped] forKey:kResultImageCropped];
-    }
+    [self setupDictionary:resultDict withImageMetadata:self.scannedImageSuccesful resultKey:kResultImageSuccessful];
 
-    if (self.scannedImageSuccesful && self.shouldReturnSuccessfulImage) {
-        [images setObject:[self exportImage:self.scannedImageSuccesful] forKey:kResultImageSuccessful];
-    }
-
-    if (self.scannedImageFace && self.shouldReturnFaceImage) {
-        [images setObject:[self exportImage:self.scannedImageFace] forKey:kResultImageFace];
-    }
-
-    [resultDict setObject:[NSDictionary dictionaryWithDictionary:images] forKey:kResultImages];
     [self finishWithScanningResults:resultDict];
 }
 
-- (void) reset {
+#pragma mark - Utils
+
+- (void)setupDictionary:(NSMutableDictionary *)dict withImageMetadata:(PPImageMetadata *)imageMetadata resultKey:(NSString *)resultKey {
+
+    if (imageMetadata == nil) return;
+    if (imageMetadata.image == nil) return;
+
+    [dict setObject:[self exportImage:imageMetadata.image] forKey:resultKey];
+}
+
+- (void)setupDictionary:(NSMutableDictionary *)dict withImagesForResult:(PPRecognizerResult *)result {
+    NSDictionary *metadatas = [self.imageMetadatas objectForKey:NSStringFromClass([result class])];
+
+    [metadatas enumerateKeysAndObjectsUsingBlock:^(id  _Nonnull key, id  _Nonnull obj, BOOL * _Nonnull stop) {
+        switch ([key intValue]) {
+            case PPImageTypeFace:
+                [self setupDictionary:dict withImageMetadata:obj resultKey:kResultImageFace];
+                break;
+            case PPImageTypeDocument:
+                [self setupDictionary:dict withImageMetadata:obj resultKey:kResultImageDocument];
+                break;
+        }
+    }];
+}
+
+- (void)setImageMetadata:(PPImageMetadata *)metadata forName:(NSString *)name imageType:(PPImageType)type resultClass:(Class)result {
+    if ([[metadata name] isEqualToString:name]) {
+        NSMutableDictionary *dict = [self.imageMetadatas objectForKey:NSStringFromClass(result)];
+        [dict setObject:metadata forKey:@(type)];
+    }
+}
+
+- (NSMutableDictionary *)getInitializedImagesDictionaryForClass:(Class)klass {
+    NSMutableDictionary *dict = [self.imageMetadatas objectForKey:NSStringFromClass(klass)];
+    if (dict != nil) {
+        return dict;
+    }
+
+    NSMutableDictionary *newDict = [[NSMutableDictionary alloc] init];
+    [self.imageMetadatas setObject:newDict forKey:NSStringFromClass(klass)];
+    return newDict;
+}
+
+- (NSDictionary*)exportImage:(UIImage*)image {
+    NSData *imageData = UIImageJPEGRepresentation(image, 0.9f);
+    NSMutableDictionary* imageInfo = [NSMutableDictionary dictionary];
+    NSString *encodedImage = [imageData base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
+    [imageInfo setObject:@(image.size.width) forKey:kWidth];
+    [imageInfo setObject:@(image.size.height) forKey:kHeight];
+    [imageInfo setObject:encodedImage forKey:kBase64];
+    return [NSDictionary dictionaryWithDictionary:imageInfo];
+}
+
+- (UIViewController*) getRootViewController {
+    UIViewController *rootViewController = [[[UIApplication sharedApplication] keyWindow] rootViewController];
+
+    return rootViewController;
+}
+
+- (void)reset {
     self.promiseResolve = nil;
     self.promiseReject = nil;
     self.options = nil;
 }
 
 
-- (void) dismissScanningView {
+- (void)dismissScanningView {
     [self reset];
     [[self getRootViewController] dismissViewControllerAnimated:YES completion:nil];
 }
 
-- (void) finishWithScanningResults:(NSDictionary*) results {
+- (void)finishWithScanningResults:(NSDictionary*) results {
     if (self.promiseResolve && results) {
         self.promiseResolve(results);
     }
-    
+
     [self dismissScanningView];
 }
 
-- (UIViewController*) getRootViewController {
-    UIViewController *rootViewController = [[[UIApplication sharedApplication] keyWindow] rootViewController];
-    
-    return rootViewController;
-}
-
-- (PPMrtdRecognizerSettings *)mrtdRecognizerSettings {
-    
-    PPMrtdRecognizerSettings *mrtdRecognizerSettings = [[PPMrtdRecognizerSettings alloc] init];
-    
-    /********* All recognizer settings are set to their default values. Change accordingly. *********/
-    
-    
-    // Setting this will give you the chance to parse MRZ result, if Mrtd recognizer wasn't
-    // successful in parsing (this can happen since MRZ isn't always formatted accoring to ICAO Document 9303 standard.
-    // @see http://www.icao.int/Security/mrtd/pages/Document9303.aspx
-    mrtdRecognizerSettings.allowUnparsedResults = NO;
-    
-    // This property is useful if you're at the same time obtaining Dewarped image metadata, since it allows you to obtain dewarped and
-    // cropped
-    // images of MRTD documents. Dewarped images are returned to scanningViewController:didOutputMetadata: callback,
-    // as PPImageMetadata objects with name @"MRTD"
-    
-    mrtdRecognizerSettings.dewarpFullDocument = self.shouldReturnCroppedImage;
-
-    return mrtdRecognizerSettings;
-}
-
-
-- (PPEudlRecognizerSettings *)eudlRecognizerSettingsWithCountry:(PPEudlCountry)country {
-    
-    PPEudlRecognizerSettings *eudlRecognizerSettings = [[PPEudlRecognizerSettings alloc] initWithEudlCountry:country];
-    
-    /********* All recognizer settings are set to their default values. Change accordingly. *********/
-    
-    /**
-     * If YES, document issue date will be extracted
-     * Set this to NO if youre not interested in this data to speed up the scanning process!
-     */
-    eudlRecognizerSettings.extractIssueDate = YES;
-    
-    /**
-     * If YES, document expiry date will be extracted
-     * Set this to NO if youre not interested in this data to speed up the scanning process!
-     */
-    eudlRecognizerSettings.extractExpiryDate = YES;
-    
-    /**
-     * If YES, owner's address will be extracted
-     * Set this to NO if youre not interested in this data to speed up the scanning process!
-     */
-    eudlRecognizerSettings.extractAddress = YES;
-    
-    // This property is useful if you're at the same time obtaining Dewarped image metadata, since it allows you to obtain dewarped and
-    // cropped
-    // images of MRTD documents. Dewarped images are returned to scanningViewController:didOutputMetadata: callback,
-    // as PPImageMetadata objects with name @"MRTD"
-    
-    eudlRecognizerSettings.showFullDocument = self.shouldReturnCroppedImage;
-    
-    return eudlRecognizerSettings;
-}
+#pragma mark - RecognizerSettings
 
 - (PPUsdlRecognizerSettings *)usdlRecognizerSettings {
-    
+
     PPUsdlRecognizerSettings *usdlRecognizerSettings = [[PPUsdlRecognizerSettings alloc] init];
-    
+
     /********* All recognizer settings are set to their default values. Change accordingly. *********/
-    
+
     /**
      * Set this to YES to scan even barcode not compliant with standards
      * For example, malformed PDF417 barcodes which were incorrectly encoded
      * Use only if necessary because it slows down the recognition process
      */
     usdlRecognizerSettings.scanUncertain = NO;
-    
+
     /**
      * Set this to YES to scan barcodes which don't have quiet zone (white area) around it
      * Disable if you need a slight speed boost
      */
     usdlRecognizerSettings.allowNullQuietZone = YES;
-    
+
     return usdlRecognizerSettings;
 }
 
-- (PPDocumentFaceRecognizerSettings *)documentFaceRecognizerSettings {
-    
-    PPDocumentFaceRecognizerSettings *documentFaceReconizerSettings = [[PPDocumentFaceRecognizerSettings alloc] init];
-    
+- (PPMrtdRecognizerSettings *)mrtdRecognizerSettings {
+
+    PPMrtdRecognizerSettings *mrtdRecognizerSettings = [[PPMrtdRecognizerSettings alloc] init];
+
+    /********* All recognizer settings are set to their default values. Change accordingly. *********/
+
+
+    // Setting this will give you the chance to parse MRZ result, if Mrtd recognizer wasn't
+    // successful in parsing (this can happen since MRZ isn't always formatted accoring to ICAO Document 9303 standard.
+    // @see http://www.icao.int/Security/mrtd/pages/Document9303.aspx
+    mrtdRecognizerSettings.allowUnparsedResults = NO;
+
     // This property is useful if you're at the same time obtaining Dewarped image metadata, since it allows you to obtain dewarped and
     // cropped
     // images of MRTD documents. Dewarped images are returned to scanningViewController:didOutputMetadata: callback,
     // as PPImageMetadata objects with name @"MRTD"
-    
-    documentFaceReconizerSettings.returnFaceImage = self.shouldReturnFaceImage;
 
-    documentFaceReconizerSettings.returnFullDocument = self.shouldReturnCroppedImage;
-    
-    return documentFaceReconizerSettings;
+    // Setup returning document image
+
+    if ([self shouldReturnDocumentImage]) {
+        mrtdRecognizerSettings.dewarpFullDocument = YES;
+
+        NSMutableDictionary *dict = [self getInitializedImagesDictionaryForClass:[PPMrtdRecognizerResult class]];
+        [dict setObject:[NSNull null] forKey:@(PPImageTypeDocument)];
+    }
+    return mrtdRecognizerSettings;
+}
+
+- (PPEudlRecognizerSettings *)eudlRecognizerSettingsWithCountry:(PPEudlCountry)country {
+
+    PPEudlRecognizerSettings *eudlRecognizerSettings = [[PPEudlRecognizerSettings alloc] initWithEudlCountry:country];
+
+    /********* All recognizer settings are set to their default values. Change accordingly. *********/
+
+    /**
+     * If YES, document issue date will be extracted
+     * Set this to NO if youre not interested in this data to speed up the scanning process!
+     */
+    eudlRecognizerSettings.extractIssueDate = YES;
+
+    /**
+     * If YES, document expiry date will be extracted
+     * Set this to NO if youre not interested in this data to speed up the scanning process!
+     */
+    eudlRecognizerSettings.extractExpiryDate = YES;
+
+    /**
+     * If YES, owner's address will be extracted
+     * Set this to NO if youre not interested in this data to speed up the scanning process!
+     */
+    eudlRecognizerSettings.extractAddress = YES;
+
+    // This property is useful if you're at the same time obtaining Dewarped image metadata, since it allows you to obtain dewarped and
+    // cropped
+    // images of MRTD documents. Dewarped images are returned to scanningViewController:didOutputMetadata: callback,
+    // as PPImageMetadata objects with name @"MRTD"
+
+    // Setup returning document image
+
+    if ([self shouldReturnDocumentImage]) {
+        eudlRecognizerSettings.showFullDocument = YES;
+
+        NSMutableDictionary *dict = [self getInitializedImagesDictionaryForClass:[PPEudlRecognizerResult class]];
+        [dict setObject:[NSNull null] forKey:@(PPImageTypeDocument)];
+    }
+
+    // Setup returning face image
+
+    if ([self shouldReturnFaceImage]) {
+        eudlRecognizerSettings.showFaceImage = YES;
+
+        NSMutableDictionary *dict = [self getInitializedImagesDictionaryForClass:[PPEudlRecognizerResult class]];
+        [dict setObject:[NSNull null] forKey:@(PPImageTypeFace)];
+    }
+
+    return eudlRecognizerSettings;
 }
 
 - (PPMyKadFrontRecognizerSettings *)myKadRecognizerSettings {
-    
+
     PPMyKadFrontRecognizerSettings *myKadRecognizerSettings = [[PPMyKadFrontRecognizerSettings alloc] init];
-    
-    myKadRecognizerSettings.showFullDocument = self.shouldReturnCroppedImage;
-    
+
+    // Setup returning document image
+
+    if ([self shouldReturnDocumentImage]) {
+        myKadRecognizerSettings.showFullDocument = YES;
+
+        NSMutableDictionary *dict = [self getInitializedImagesDictionaryForClass:[PPMyKadFrontRecognizerResult class]];
+        [dict setObject:[NSNull null] forKey:@(PPImageTypeDocument)];
+    }
+
+    // Setup returning face image
+
+    if ([self shouldReturnFaceImage]) {
+        myKadRecognizerSettings.showFaceImage = YES;
+
+        NSMutableDictionary *dict = [self getInitializedImagesDictionaryForClass:[PPMyKadFrontRecognizerResult class]];
+        [dict setObject:[NSNull null] forKey:@(PPImageTypeFace)];
+    }
+
     return myKadRecognizerSettings;
+}
+
+- (PPNewZealandDLFrontRecognizerSettings *)nzdlFrontRecognizerSettings {
+
+    PPNewZealandDLFrontRecognizerSettings *nzdlFrontRecognizerSettings = [[PPNewZealandDLFrontRecognizerSettings alloc] init];
+
+    /********* All recognizer settings are set to their default values. Change accordingly. *********/
+
+
+    // Setup returning document image
+
+    if ([self shouldReturnDocumentImage]) {
+        nzdlFrontRecognizerSettings.displayFullDocumentImage = YES;
+
+        NSMutableDictionary *dict = [self getInitializedImagesDictionaryForClass:[PPNewZealandDLFrontRecognizerResult class]];
+        [dict setObject:[NSNull null] forKey:@(PPImageTypeDocument)];
+    }
+
+    // Setup returning face image
+
+    if ([self shouldReturnFaceImage]) {
+        nzdlFrontRecognizerSettings.displayFacePhoto = YES;
+
+        NSMutableDictionary *dict = [self getInitializedImagesDictionaryForClass:[PPNewZealandDLFrontRecognizerResult class]];
+        [dict setObject:[NSNull null] forKey:@(PPImageTypeFace)];
+    }
+
+
+    return nzdlFrontRecognizerSettings;
+}
+
+- (PPDocumentFaceRecognizerSettings *)documentFaceRecognizerSettings {
+
+    PPDocumentFaceRecognizerSettings *documentFaceReconizerSettings = [[PPDocumentFaceRecognizerSettings alloc] init];
+
+    // This property is useful if you're at the same time obtaining Dewarped image metadata, since it allows you to obtain dewarped and
+    // cropped
+    // images of MRTD documents. Dewarped images are returned to scanningViewController:didOutputMetadata: callback,
+    // as PPImageMetadata objects with name @"MRTD"
+
+    // Setup returning document image
+
+    if ([self shouldReturnDocumentImage]) {
+        documentFaceReconizerSettings.returnFullDocument = YES;
+
+        NSMutableDictionary *dict = [self getInitializedImagesDictionaryForClass:[PPDocumentFaceRecognizerResult class]];
+        [dict setObject:[NSNull null] forKey:@(PPImageTypeDocument)];
+    }
+
+    // Setup returning face image
+
+    if ([self shouldReturnFaceImage]) {
+        documentFaceReconizerSettings.returnFaceImage = YES;
+
+        NSMutableDictionary *dict = [self getInitializedImagesDictionaryForClass:[PPDocumentFaceRecognizerResult class]];
+        [dict setObject:[NSNull null] forKey:@(PPImageTypeFace)];
+    }
+
+    return documentFaceReconizerSettings;
 }
 
 - (PPPdf417RecognizerSettings *)pdf417RecognizerSettings {
@@ -631,16 +824,6 @@ RCT_REMAP_METHOD(scan, scan:(NSString *)key withOptions:(NSDictionary*)scanOptio
     pdf417RecognizerSettings.allowNullQuietZone = YES;
 
     return pdf417RecognizerSettings;
-}
-
-- (NSDictionary*) exportImage:(UIImage*)image {
-    NSData *imageData = UIImageJPEGRepresentation(image, 0.9f);
-    NSMutableDictionary* imageInfo = [NSMutableDictionary dictionary];
-    NSString *encodedImage = [imageData base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
-    [imageInfo setObject:@(image.size.width) forKey:@"width"];
-    [imageInfo setObject:@(image.size.height) forKey:@"height"];
-    [imageInfo setObject:encodedImage forKey:@"base64"];
-    return [NSDictionary dictionaryWithDictionary:imageInfo];
 }
 
 @end


### PR DESCRIPTION
 * [android] updated to BlinkID SDK v3.16.0
 * [ios] Updated SDK version to v2.17.3
 * added support for **New Zealand driver's license**
 * **[Breaking API change]** refactored image export:
     - Renamed `CroppedImage` to `DocumentImage` 
     - `Successful` image is still returned in `scanningResult.resultImageSuccessful`
     - `Document`(previously cropped) and `Face` images are now contained in `scanningResult.resultList[i].resultImageDocument` and `scanningResult.resultList[i].resultImageFace` respectively.