### PR TITLE
feat: support custom tooltip texts

### DIFF
--- a/BlinkID/overlays/blinkidOverlays.js
+++ b/BlinkID/overlays/blinkidOverlays.js
@@ -5,8 +5,10 @@ import { OverlaySettings } from '../overlaySettings'
  * Document overlay is best suited for recognizers that perform ID document scanning.
  */
 export class DocumentOverlaySettings extends OverlaySettings {
-    constructor() {
+    constructor(opts={}) {
         super('DocumentOverlaySettings');
+        /** tootlip text that is defined under document view finder. */
+        this.tooltipText = opts.tooltipText;;
     }
 }
 
@@ -15,7 +17,52 @@ export class DocumentOverlaySettings extends OverlaySettings {
  * Document verification overlay is best suited for combined recognizers - recognizer that perform scanning of both sides of ID documents.
  */
 export class DocumentVerificationOverlaySettings extends OverlaySettings {
-    constructor() {
+    constructor(opts={}) {
         super('DocumentVerificationOverlaySettings');
-    }    
+
+        /**
+         * Returns/sets user instructions that are shown above camera preview while the first side of the
+         * document is being scanned.
+         *
+         * Default: string defined by "photopay_front_verification_document"
+         * key in strings file in Microblink.bundle
+         */
+        this.firstSideInstructions = opts.firstSideInstructions;
+
+        /**
+         * Returns/sets user instructions that are shown above camera preview while the second side of the
+         * document is being scanned.
+         *
+         * Default: string defined by "photopay_back_verification_document"
+         * key in strings file in Microblink.bundle
+         */
+        this.secondSideInstructions = opts.secondSideInstructions;
+
+        /**
+         * Returns/sets splash message that is shown before scanning the first side of the document,
+         * while starting camera.
+         *
+         * Default: string defined by "photopay_front_splash_verification_document"
+         * key in strings file in Microblink.bundle
+         */
+        this.firstSideSplashMessage = opts.firstSideSplashMessage;
+
+        /**
+         * Returns/sets splash message that is shown before scanning the second side of the document,
+         * while starting camera.
+         *
+         * Default: string defined by "photopay_back_splash_verification_document"
+         * key in strings file in Microblink.bundle
+         */
+        this.secondSideSplashMessage = opts.secondSideSplashMessage;
+
+        /**
+         * Returns/sets glare status message that is shown if glare detection is turned on
+         * and it is shown if glare is detected.
+         *
+         * Default: string defined by "photopay_glare_status"
+         * key in strings file in Microblink.bundle
+         */
+        this.glareStatusMessage = opts.glareStatusMessage;
+    }
 }

--- a/BlinkID/src/ios/MicroblinkModule/MicroblinkModule/Overlays/MBOverlaySerializationUtils.m
+++ b/BlinkID/src/ios/MicroblinkModule/MicroblinkModule/Overlays/MBOverlaySerializationUtils.m
@@ -37,6 +37,47 @@
             }
         }
     }
+
+    if ([overlaySettings isKindOfClass:[MBDocumentOverlaySettings class]]) {
+        MBDocumentOverlaySettings *docOverlaySettings = (MBDocumentOverlaySettings*)overlaySettings;
+        {
+            id tooltipText = [jsonOverlaySettings objectForKey:@"tooltipText"];
+            if (tooltipText != nil && tooltipText != NSNull.null) {
+                docOverlaySettings.tooltipText = (NSString *)tooltipText;
+            }
+        }
+    }
+
+    if ([overlaySettings isKindOfClass:[MBDocumentVerificationOverlaySettings class]]) {
+        MBDocumentVerificationOverlaySettings *docVerOverlaySettings = (MBDocumentVerificationOverlaySettings*)overlaySettings;
+        {
+            id firstSideInstructions = [jsonOverlaySettings objectForKey:@"firstSideInstructions"];
+            if (firstSideInstructions != nil && firstSideInstructions != NSNull.null) {
+                docVerOverlaySettings.firstSideInstructions = (NSString *)firstSideInstructions;
+            }
+        }
+
+        {
+            id secondSideInstructions = [jsonOverlaySettings objectForKey:@"secondSideInstructions"];
+            if (secondSideInstructions != nil && secondSideInstructions != NSNull.null) {
+                docVerOverlaySettings.secondSideInstructions = (NSString *)secondSideInstructions;
+            }
+        }
+
+        {
+            id firstSideSplashMessage = [jsonOverlaySettings objectForKey:@"firstSideSplashMessage"];
+            if (firstSideSplashMessage != nil && firstSideSplashMessage != NSNull.null) {
+                docVerOverlaySettings.firstSideSplashMessage = (NSString *)firstSideSplashMessage;
+            }
+        }
+
+        {
+            id secondSideSplashMessage = [jsonOverlaySettings objectForKey:@"secondSideSplashMessage"];
+            if (secondSideSplashMessage != nil && secondSideSplashMessage != NSNull.null) {
+                docVerOverlaySettings.secondSideSplashMessage = (NSString *)secondSideSplashMessage;
+            }
+        }
+    }
 }
 
 @end


### PR DESCRIPTION
currently it only works on iOS

is it possible on Android? I see all the settings classes only accept resource ids, e.g. `(DocumentVerificationUISettings uiSettings).setFirstSideInstructionsResourceID(rid)`. Maybe someone can help :)