### PR TITLE
fix: relax react-native dep constraint...

### DIFF
--- a/BlinkID/src/android/build.gradle
+++ b/BlinkID/src/android/build.gradle
@@ -25,7 +25,7 @@ repositories {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile "com.android.support:appcompat-v7:26.1.0"
-    compile "com.facebook.react:react-native:0.56.0"
+    compile 'com.facebook.react:react-native:+'
     compile('com.microblink:blinkid:4.2.0@aar') {
         transitive = false
     }


### PR DESCRIPTION
...this library works with RN 55 too, and is impossible to use if 0.56 is explicitly specified